### PR TITLE
gitignore(fix): add .dockerignore file as symlink on .gitignore 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ relayer/tools/admin.key.json
 # log file
 eventbridge.log*
 protocol.log*
+
+# venv files:
+venv/


### PR DESCRIPTION
## Description

gitignore(fix): add .dockerignore file as symlink on .gitignore - help with , add venv folder to limit docker build context

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

BREAKING CHANGE - user now need to provide volume path to the relayer like `/home/ubuntu/bifrost-relayer:/relayer`
Please update https://docs.thebifrost.io/bifrost-network/running-a-node/setting-up-a-relayer/using-docker accordingly! 
