### PR TITLE
change cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ bitarray==2.6.0
 certifi==2022.9.24
 cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==38.0.2
+cryptography==38.0.1
 cytoolz==0.12.0
 dataclasses-json==0.5.7
 ecdsa==0.18.0


### PR DESCRIPTION
cryptography 38.0.2 is yanked from PyPI due to a regression in OpenSSL

## Description

Please include a summary of the changes you request.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)
