### PR TITLE
[refactor] - fixed Dockerfile linter issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,14 @@ FROM python:3.10-slim
 
 ENV PRIVATE_KEY=
 
-RUN apt update && apt install -y build-essential gcc
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/
 
 WORKDIR /app
 COPY . .
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT python relayer-launcher.py launch -k $PRIVATE_KEY
+ENTRYPOINT ["/bin/bash","-c","python relayer-launcher.py"]
+CMD ["launch -k $PRIVATE_KEY"]


### PR DESCRIPTION
## Description

main fix DL3025 - use arguments JSON notation for CMD and ENTRYPOINT arguments, start to use ENTRYPOINT in JSON notation with CMD - it allows users to overwrite default stable CMD arguments minor stuff:

    DL3027-Do not use apt as it is meant to be an end-user tool, use apt-get or apt-cache instead
    DL3042 - Avoid cache directory with pip install --no-cache-dir


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

## Tested on my 1.0.7 setup