### PR TITLE
[fix/using-labels-for-separator] Using labels as separator

### DIFF
--- a/relayer-launcher.py
+++ b/relayer-launcher.py
@@ -65,7 +65,7 @@ def main(_config: dict):
         relayer.register_offchain_event_obj("heart_beat", RelayerHeartBeat)
 
     if prometheus_on:
-        PrometheusExporterRelayer.init_prometheus_exporter_on_relayer()
+        PrometheusExporterRelayer.init_prometheus_exporter_on_relayer(relayer.supported_chain_list)
 
     relayer.run_relayer()
 


### PR DESCRIPTION
## Description

* Instead of having a separators in the metric name, changed to using labels as separators.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else (simple changes that are not related to existing functionality or others)
